### PR TITLE
Add backward compatibility for MPTCP_ENABLED

### DIFF
--- a/src/netutils.h
+++ b/src/netutils.h
@@ -52,9 +52,13 @@
 
 #endif
 
-/* Define the flag MPTCP_ENABLED if not defined*/
+/* Backward compatibility for MPTCP_ENABLED between kernel 3 & 4 */
 #ifndef MPTCP_ENABLED
+#ifdef TCP_CC_INFO
 #define MPTCP_ENABLED 42
+#else
+#define MPTCP_ENABLED 26
+#endif
 #endif
 
 /** byte size of ip4 address */


### PR DESCRIPTION
MPTCP_ENABLED value changed from 26 to 42 because upstream kernel v4 introduced new TCP_CC_INFO constant which takes MPTCP_ENABLED's old value 26.
