### PR TITLE
mptcp: make shadowsocks kernel independant

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -929,9 +929,21 @@ static remote_t *create_remote(listen_ctx_t *listener,
     setsockopt(remotefd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
 
-    if (listener->mptcp == 1) {
-        int err = setsockopt(remotefd, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
+    if (listener->mptcp > 1) {
+        int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
+            ERROR("failed to enable multipath TCP");
+        }
+    } else if (listener->mptcp == 1) {
+        int i = 0;
+        while((listener->mptcp = mptcp_enabled_values[i]) > 0) {
+            int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
+            if (err != -1) {
+                break;
+            }
+            i++;
+        }
+        if (listener->mptcp == 0) {
             ERROR("failed to enable multipath TCP");
         }
     }

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -52,13 +52,11 @@
 
 #endif
 
-/* Backward compatibility for MPTCP_ENABLED between kernel 3 & 4 */
+/* MPTCP_ENABLED setsockopt values for kernel 4 & 3, best behaviour to be independant of kernel version is to test from newest to the latest values */
 #ifndef MPTCP_ENABLED
-#ifdef TCP_CC_INFO
-#define MPTCP_ENABLED 42
+static const char mptcp_enabled_values[] = { 42, 26, 0 };
 #else
-#define MPTCP_ENABLED 26
-#endif
+static const char mptcp_enabled_values[] = { MPTCP_ENABLED, 0 };
 #endif
 
 /** byte size of ip4 address */

--- a/src/redir.c
+++ b/src/redir.c
@@ -649,9 +649,21 @@ static void accept_cb(EV_P_ ev_io *w, int revents)
     }
 
     // Enable MPTCP
-    if (listener->mptcp == 1) {
-        int err = setsockopt(remotefd, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
+    if (listener->mptcp > 1) {
+        int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
+            ERROR("failed to enable multipath TCP");
+        }
+    } else if (listener->mptcp == 1) {
+        int i = 0;
+        while((listener->mptcp = mptcp_enabled_values[i]) > 0) {
+            int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
+            if (err != -1) {
+                break;
+            }
+            i++;
+        }
+        if (listener->mptcp == 0) {
             ERROR("failed to enable multipath TCP");
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -421,9 +421,13 @@ int create_and_bind(const char *host, const char *port, int mptcp)
         }
 
         if (mptcp == 1) {
-            err = setsockopt(listen_sock, IPPROTO_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
-            if (err == -1) {
-                continue;
+            int i = 0;
+            while((mptcp = mptcp_enabled_values[i]) > 0) {
+                err = setsockopt(listen_sock, IPPROTO_TCP, mptcp, &opt, sizeof(opt));
+                if (err != -1) {
+                    break;
+                }
+                i++;
             }
         }
 
@@ -443,7 +447,7 @@ int create_and_bind(const char *host, const char *port, int mptcp)
         return -1;
     }
 
-    if (mptcp == 1) {
+    if (mptcp > 1) {
         LOGI("MPTCP enabled");
     }
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -654,9 +654,21 @@ static void accept_cb(EV_P_ ev_io *w, int revents)
     setsockopt(remotefd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
 
-    if (listener->mptcp == 1) {
-        int err = setsockopt(remotefd, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
+    if (listener->mptcp > 1) {
+        int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
+            ERROR("failed to enable multipath TCP");
+        }
+    } else if (listener->mptcp == 1) {
+       int i = 0;
+       while((listener->mptcp = mptcp_enabled_values[i]) > 0) {
+            int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
+            if (err != -1) {
+                break;
+            }
+            i++;
+        }
+        if (listener->mptcp == 0) {
             ERROR("failed to enable multipath TCP");
         }
     }


### PR DESCRIPTION
According to mptcp developers the best way to make mptcp applications kernel idependant is to try setsockopt MPTCP_ENABLED value from the newer to older.